### PR TITLE
Suppress redundant error messages

### DIFF
--- a/lib/remote_syslog_sender/sender.rb
+++ b/lib/remote_syslog_sender/sender.rb
@@ -48,8 +48,11 @@ module RemoteSyslogSender
           packet.content = line
           send_msg(packet.assemble(@packet_size))
         rescue
-          $stderr.puts "#{self.class} error: #{$!.class}: #{$!}\nOriginal message: #{line}"
-          raise if @whinyerrors
+          if @whinyerrors
+            raise
+          else
+            $stderr.puts "#{self.class} error: #{$!.class}: #{$!}\nOriginal message: #{line}"
+          end
         end
       end
     end


### PR DESCRIPTION
The error message from `$stderr.puts` is redundant
if `whinyerrors` is true.
In addition, I think it shouldn't be displayed
if the raised error is rescued.