### PR TITLE
Remove verification error when certificate check is not OK

### DIFF
--- a/lib/remote_syslog_sender/tcp_sender.rb
+++ b/lib/remote_syslog_sender/tcp_sender.rb
@@ -70,7 +70,7 @@ module RemoteSyslogSender
             @socket = OpenSSL::SSL::SSLSocket.new(@tcp_socket, context)
             @socket.connect
             @socket.post_connection_check(@remote_hostname)
-            raise "verification error" if @socket.verify_result != OpenSSL::X509::V_OK
+            raise "verification error" if @socket.verify_result != OpenSSL::X509::V_OK and context.verify_mode != OpenSSL::SSL::VERIFY_NONE
           else
             @socket = @tcp_socket
           end


### PR DESCRIPTION
As stated in documentation of OpenSSL found here:
https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_set_verify.html
The SSL_VERIFY_NONE client mode is currently not possible.
This leads to not having the possiblity to use TCP with SSL and
always trust on the certificate provided by the remote server,
for example for dev purposes.

Signed-off-by: Nikolay Stanchev <nstanchev@vmware.com>