### PR TITLE
WIP: Ability to use ssl_min_version and/or ssl_max_version instead of ssl_method

### DIFF
--- a/lib/remote_syslog_sender/tcp_sender.rb
+++ b/lib/remote_syslog_sender/tcp_sender.rb
@@ -65,12 +65,40 @@ module RemoteSyslogSender
           end
           if @tls
             require 'openssl'
+
+            min_max_available = true
+            tls_versions_map = {}
+            begin
+              tls_versions_map = {
+                TLSv1: OpenSSL::SSL::TLS1_VERSION,
+                TLSv1_1: OpenSSL::SSL::TLS1_1_VERSION,
+                TLSv1_2: OpenSSL::SSL::TLS1_2_VERSION
+              }
+              tls_versions_map[:'TLSv1_3'] = OpenSSL::SSL::TLS1_3_VERSION if defined?(OpenSSL::SSL::TLS1_3_VERSION)
+            rescue NameError
+              # ruby 2.4 doesn't have OpenSSL::SSL::TLSXXX constants and min_version=/max_version= methods
+              tls_versions_map = {
+                TLSv1: :'TLSv1',
+                TLSv1_1: :'TLSv1_1',
+                TLSv1_2: :'TLSv1_2',
+              }
+              min_max_available = false
+            end
+
             context = OpenSSL::SSL::SSLContext.new()
-            if @ssl_min_version || @ssl_max_version
-              context.min_version = @ssl_min_version
-              context.max_version = @ssl_max_version
+            if min_max_available
+              case
+                when @ssl_min_version && @ssl_max_version
+                  context.min_version = @ssl_min_version
+                  context.max_version = @ssl_max_version
+                when (!@ssl_min_version && @ssl_max_version) || (@ssl_min_version && !@ssl_max_version)
+                  raise "Both :ssl_min_version and :ssl_max_version must be set if one is"
+              else
+                context.min_version = tls_versions_map[@ssl_min_version] || @ssl_min_version
+                context.max_version = tls_versions_map[@ssl_max_version] || @ssl_max_version
+              end
             else
-              context.ssl_version = @ssl_method
+              context.ssl_version = METHODS_MAP[@ssl_method] || @ssl_method
             end
             context.ca_file = @ca_file if @ca_file
             context.verify_mode = @verify_mode if @verify_mode

--- a/lib/remote_syslog_sender/tcp_sender.rb
+++ b/lib/remote_syslog_sender/tcp_sender.rb
@@ -88,11 +88,14 @@ module RemoteSyslogSender
             context = OpenSSL::SSL::SSLContext.new()
             if min_max_available
               case
-                when @ssl_min_version && @ssl_max_version
-                  context.min_version = @ssl_min_version
-                  context.max_version = @ssl_max_version
-                when (!@ssl_min_version && @ssl_max_version) || (@ssl_min_version && !@ssl_max_version)
-                  raise "Both :ssl_min_version and :ssl_max_version must be set if one is"
+              when @ssl_min_version && @ssl_max_version
+                context.min_version = @ssl_min_version
+                context.max_version = @ssl_max_version
+              when (!@ssl_min_version && @ssl_max_version) || (@ssl_min_version && !@ssl_max_version)
+                raise "Both :ssl_min_version and :ssl_max_version must be set if one is"
+              when !@ssl_min_version && !@ssl_max_version
+                # Keep the current behaviour
+                context.ssl_version = METHODS_MAP[@ssl_method] || @ssl_method
               else
                 context.min_version = tls_versions_map[@ssl_min_version] || @ssl_min_version
                 context.max_version = tls_versions_map[@ssl_max_version] || @ssl_max_version

--- a/lib/remote_syslog_sender/tcp_sender.rb
+++ b/lib/remote_syslog_sender/tcp_sender.rb
@@ -14,6 +14,8 @@ module RemoteSyslogSender
       @remote_hostname = remote_hostname
       @remote_port     = remote_port
       @ssl_method      = options[:ssl_method] || 'TLSv1_2'
+      @ssl_min_version = options[:ssl_min_version]
+      @ssl_max_version = options[:ssl_max_version]
       @ca_file         = options[:ca_file]
       @verify_mode     = options[:verify_mode]
       @timeout         = options[:timeout] || 600
@@ -63,7 +65,13 @@ module RemoteSyslogSender
           end
           if @tls
             require 'openssl'
-            context = OpenSSL::SSL::SSLContext.new(@ssl_method)
+            context = OpenSSL::SSL::SSLContext.new()
+            if @ssl_min_version || @ssl_max_version
+              context.min_version = @ssl_min_version
+              context.max_version = @ssl_max_version
+            else
+              context.ssl_version = @ssl_method
+            end
             context.ca_file = @ca_file if @ca_file
             context.verify_mode = @verify_mode if @verify_mode
 


### PR DESCRIPTION
`ssl_method` param can only be used up to TLS 1.2 version in openssl (as stated in https://github.com/ruby/openssl/issues/473#issuecomment-964252959).

This PR introduces params `ssl_min_version` and `ssl_max_version`.

If neither of these is set, the current behaviour still stands and `ssl_method` param is used.
Otherwise, `ssl_min_version` and `ssl_max_version` are passed to ssl context.