### PR TITLE
Making TCP_USER_TIMEOUT socket option user configurable

### DIFF
--- a/lib/remote_syslog_sender/tcp_sender.rb
+++ b/lib/remote_syslog_sender/tcp_sender.rb
@@ -19,6 +19,7 @@ module RemoteSyslogSender
       @timeout         = options[:timeout] || 600
       @timeout_exception   = !!options[:timeout_exception]
       @exponential_backoff = !!options[:exponential_backoff]
+      @tcp_user_timeout = options[:tcp_user_timeout] || 5
 
       @mutex = Mutex.new
       @tcp_socket = nil
@@ -54,7 +55,7 @@ module RemoteSyslogSender
           close
 
           @tcp_socket = TCPSocket.new(@remote_hostname, @remote_port)
-
+          @tcp_socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_USER_TIMEOUT, @tcp_user_timeout)
           if @keep_alive
             @tcp_socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true)
             @tcp_socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_KEEPIDLE, @keep_alive_idle) if @keep_alive_idle

--- a/remote_syslog_sender.gemspec
+++ b/remote_syslog_sender.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = 'remote_syslog_sender'
-  s.version           = '1.2.2'
+  s.version           = '1.2.3'
   s.summary     = "Message sender that sends directly to a remote syslog endpoint"
   s.description = "Message sender that sends directly to a remote syslog endpoint (Support UDP, TCP, TCP+TLS)"
 


### PR DESCRIPTION
This PR is for making the  TCP_USER_TIMEOUT socket option user configurable. 