### PR TITLE
Support Server Name Indication (SNI) in TLS handshake

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,3 +10,4 @@ end
 require 'remote_syslog_sender'
 
 require 'test/unit'
+require 'openssl'

--- a/test/test_remote_syslog_logger.rb
+++ b/test/test_remote_syslog_logger.rb
@@ -64,3 +64,73 @@ class TestRemoteSyslogSender < Test::Unit::TestCase
     assert_match(/This is the second line/, message)
   end
 end
+
+class TestRemoteSyslogTLSSender < Test::Unit::TestCase
+  def setup
+    @key = OpenSSL::PKey::RSA.new(2048)
+    @cert = OpenSSL::X509::Certificate.new
+    @cert.version = 2
+    @cert.serial = 1
+    @cert.subject = OpenSSL::X509::Name.parse("/CN=localhost")
+    @cert.issuer = @cert.subject
+    @cert.public_key = @key.public_key
+    @cert.not_before = Time.now
+    @cert.not_after = Time.now + 3600
+    @cert.sign(@key, OpenSSL::Digest::SHA256.new)
+
+    tcp_server = TCPServer.open('127.0.0.1', 0)
+    @tcp_server_port = tcp_server.addr[1]
+
+    ctx = OpenSSL::SSL::SSLContext.new
+    ctx.cert = @cert
+    ctx.key = @key
+
+    @ssl_server = OpenSSL::SSL::SSLServer.new(tcp_server, ctx)
+
+    @tcp_server_wait_thread = Thread.start do
+      @ssl_server.accept
+    end
+  end
+
+  def teardown
+    @ssl_server.close
+  end
+
+  def test_sender_tls_no_sni
+    @sender = RemoteSyslogSender::TcpSender.new(
+      '127.0.0.1',
+      @tcp_server_port,
+      tls: true,
+      verify_mode: OpenSSL::SSL::VERIFY_NONE
+    )
+
+    @sender.write "This is a test"
+    sock = @tcp_server_wait_thread.value
+
+    message, _ = *sock.read_nonblock(256)
+    assert_match(/This is a test/, message)
+
+    # When remote hostname is an IP address, SNI hostname is not set.
+    socket = @sender.instance_variable_get(:@socket)
+    assert_nil(socket.hostname)
+  end
+
+  def test_sender_tls_sni
+    @sender = RemoteSyslogSender::TcpSender.new(
+      'localhost',
+      @tcp_server_port,
+      tls: true,
+      verify_mode: OpenSSL::SSL::VERIFY_NONE
+    )
+
+    @sender.write "This is a test"
+    sock = @tcp_server_wait_thread.value
+
+    message, _ = *sock.read_nonblock(256)
+    assert_match(/This is a test/, message)
+
+    # When remote hostname is a hostname, SNI hostname is not set.
+    socket = @sender.instance_variable_get(:@socket)
+    assert_equal('localhost', socket.hostname)
+  end
+end


### PR DESCRIPTION
Without SNI support, the TLS handshake fails when the remote server hosts multiple domains with different certificates on a single IP address. In such cases, the server requires the SNI extension to determine which certificate to present to the client.

Ref: https://github.com/fluent-plugins-nursery/fluent-plugin-remote_syslog/issues/70


## How to reproduce
### Prepare
```
$ sudo cat <<EOF | sudo tee -a /etc/hosts
127.0.0.1   site-a.test
127.0.0.1   site-b.test
EOF
```

### server code
```ruby
require 'socket'
require 'openssl'
require 'fileutils'

PORT = 5140
DIR = "test_certs"
HOST_A = "site-a.test"
HOST_B = "site-b.test"

FileUtils.mkdir_p(DIR)

def generate_cert(cn, ca_cert: nil, ca_key: nil)
  key = OpenSSL::PKey::RSA.new(2048)
  cert = OpenSSL::X509::Certificate.new
  cert.version = 2
  cert.serial = Time.now.to_i + rand(10000)
  cert.subject = OpenSSL::X509::Name.parse("/CN=#{cn}")

  if ca_cert
    cert.issuer = ca_cert.subject
    extension_factory = OpenSSL::X509::ExtensionFactory.new
    extension_factory.subject_certificate = cert
    extension_factory.issuer_certificate = ca_cert
    cert.add_extension(extension_factory.create_extension("basicConstraints", "CA:FALSE"))
    cert.add_extension(extension_factory.create_extension("subjectAltName", "DNS:#{cn}"))
  else
    cert.issuer = cert.subject
    extension_factory = OpenSSL::X509::ExtensionFactory.new
    extension_factory.subject_certificate = cert
    extension_factory.issuer_certificate = cert
    cert.add_extension(extension_factory.create_extension("basicConstraints", "CA:TRUE"))
  end

  cert.public_key = key.public_key
  cert.not_before = Time.now
  cert.not_after = Time.now + 3600

  signing_key = ca_key || key
  cert.sign(signing_key, OpenSSL::Digest::SHA256.new)

  return key, cert
end

puts "=== 1. Generating Certificates ==="

ca_key, ca_cert = generate_cert("MyLocalCA")
File.write("#{DIR}/ca_cert.pem", ca_cert.to_pem)
puts "Generated: #{DIR}/ca_cert.pem (Client use this!)"

key_a, cert_a = generate_cert(HOST_A, ca_cert: ca_cert, ca_key: ca_key)
key_b, cert_b = generate_cert(HOST_B, ca_cert: ca_cert, ca_key: ca_key)


puts "=== 2. Starting SNI Server ==="

ctx_default = OpenSSL::SSL::SSLContext.new
ctx_default.cert = cert_a
ctx_default.key = key_a

ctx_a = OpenSSL::SSL::SSLContext.new
ctx_a.cert = cert_a
ctx_a.key = key_a

ctx_b = OpenSSL::SSL::SSLContext.new
ctx_b.cert = cert_b
ctx_b.key = key_b

ctx_default.servername_cb = proc do |sock, hostname|
  case hostname
  when HOST_A
    puts "  [SNI Match] Client requested '#{hostname}' -> Switching to Cert A"
    ctx_a
  when HOST_B
    puts "  [SNI Match] Client requested '#{hostname}' -> Switching to Cert B"
    ctx_b
  else
    puts "  [SNI Unknown] Client requested '#{hostname}' -> Using default"
    ctx_default
  end
end

server = TCPServer.new(PORT)
ssl_server = OpenSSL::SSL::SSLServer.new(server, ctx_default)

puts "Server listening on port #{PORT}..."
puts "Try connecting with: host #{HOST_A} or #{HOST_B}"
puts "--------------------------------------------------"

loop do
  begin
    sock = ssl_server.accept
    cert = sock.peer_cert_chain&.first || sock.cert
    subject = sock.context.cert.subject

    puts "  -> Connection established."
    puts "  -> Server served certificate for: #{subject}"
    sock.close
  rescue => e
    puts "  -> Error: #{e.message}"
  end
  puts "--------------------------------------------------"
end
```

### client
```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'remote_syslog_sender'
end

require 'openssl'

sender = RemoteSyslogSender.new(
  'site-b.test',
  5140,
  protocol: :tcp,
  tls: true,
  ca_file: File.expand_path('test_certs/ca_cert.pem'))

sender.transmit("message body")
```

## Result
### Before
When the server uses two certificates, a connection error occurs before modification when using the certificate for 'site-b.test'

```
$ ruby server.rb
=== 1. Generating Certificates ===
Generated: test_certs/ca_cert.pem (Client use this!)
=== 2. Starting SNI Server ===
Server listening on port 5140...
Try connecting with: host site-a.test or site-b.test
--------------------------------------------------
  -> Connection established.
  -> Server served certificate for: /CN=site-a.test
--------------------------------------------------
  -> Connection established.
  -> Server served certificate for: /CN=site-a.test
--------------------------------------------------
  -> Connection established.
  -> Server served certificate for: /CN=site-a.test
--------------------------------------------------
  -> Connection established.
  -> Server served certificate for: /CN=site-a.test
--------------------------------------------------
```

```
$ ruby remote-syslog.rb
/home/watson/.rbenv/versions/3.4.8/lib/ruby/3.4.0/openssl/ssl.rb:444:in 'OpenSSL::SSL::SSLSocket#post_connection_check': hostname "site-b.test" does not match the server certificate (OpenSSL::SSL::SSLError)
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/remote_syslog_sender-1.2.2/lib/remote_syslog_sender/tcp_sender.rb:73:in 'block in RemoteSyslogSender::TcpSender#connect'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/remote_syslog_sender-1.2.2/lib/remote_syslog_sender/tcp_sender.rb:52:in 'Thread::Mutex#synchronize'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/remote_syslog_sender-1.2.2/lib/remote_syslog_sender/tcp_sender.rb:52:in 'RemoteSyslogSender::TcpSender#connect'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/remote_syslog_sender-1.2.2/lib/remote_syslog_sender/tcp_sender.rb:38:in 'RemoteSyslogSender::TcpSender#initialize'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/remote_syslog_sender-1.2.2/lib/remote_syslog_sender.rb:11:in 'Class#new'
        from /home/watson/.rbenv/versions/3.4.8/lib/ruby/gems/3.4.0/gems/remote_syslog_sender-1.2.2/lib/remote_syslog_sender.rb:11:in 'RemoteSyslogSender.new'
        from remote-syslog.rb:9:in '<main>'
```


### After
The certificate for 'site-b.test' file is selected properly and connection succeeded

```
$ ruby server.rb
=== 1. Generating Certificates ===
Generated: test_certs/ca_cert.pem (Client use this!)
=== 2. Starting SNI Server ===
Server listening on port 5140...
Try connecting with: host site-a.test or site-b.test
--------------------------------------------------
  [SNI Match] Client requested 'site-b.test' -> Switching to Cert B
  -> Connection established.
  -> Server served certificate for: /CN=site-b.test
--------------------------------------------------
```

```
$ ruby remote-syslog.rb
```