### PR TITLE
Use OpenSSL's saner default params

### DIFF
--- a/lib/remote_syslog_sender/tcp_sender.rb
+++ b/lib/remote_syslog_sender/tcp_sender.rb
@@ -67,8 +67,10 @@ module RemoteSyslogSender
           if @tls
             require 'openssl'
             context = OpenSSL::SSL::SSLContext.new(@ssl_method)
-            context.ca_file = @ca_file if @ca_file
-            context.verify_mode = @verify_mode if @verify_mode
+            context.set_params({
+              ca_file: @ca_file,
+              verify_mode: @verify_mode
+            }.compact)
 
             @socket = OpenSSL::SSL::SSLSocket.new(@tcp_socket, context)
             @socket.hostname = @remote_hostname unless @remote_hostname_is_ipaddr


### PR DESCRIPTION
In the current version, using `remote_syslog_sender` in TCP+TLS mode without providing a custom CA file and with verification enabled always fails, even when the remote host has a valid certificate :
```
> RemoteSyslogSender.new('...', 6514, protocol: :tcp, tls: true)
RuntimeError: verification error
from /.../remote_syslog_sender/lib/remote_syslog_sender/tcp_sender.rb:78:in `block in connect'
```

This is because we don't give any CA to OpenSSL, and building the context of the session manually does not set the default `cert_store` properly.

Using [`#set_params`](https://docs.ruby-lang.org/en/master/OpenSSL/SSL/SSLContext.html#method-i-set_params) instead of updating the context manually "sets saner defaults optimized for the use with HTTP-like protocols". In particular, it sets the `cert_store` to use the OS' defaults, which in my opinion is the expected behavior.